### PR TITLE
fix to small typos and missing commas in the readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,18 +21,18 @@ There are many areas we can use contributions - ranging from code, documentation
 
 ## Get Help.
 
-Do reach out on Slack or Twitter and we are happy to help.
+Do reach out on Slack or Twitter, and we are happy to help.
 
  * Drop by the [slack channel](http://slack.fission.io).
  * Say hi on [twitter](https://twitter.com/fissionio).
 
 ## Contributing - building & deploying
 
-The job of the connector is to read messages from the event source, do some action, and write response or error in the respective queues/topics. The event source could be a queue/topic for a message queue and could be a table/row in case of a database. It will be best explained in context of one sample implementation and you can extrapolate that when writing a new connector.
+The job of the connector is to read messages from the event source, do some action, and write response or error in the respective queues/topics. The event source could be a queue/topic for a message queue and could be a table/row in case of a database. It will be best explained in context of one sample implementation, and you can extrapolate that when writing a new connector.
 
 ### rabbitmq-http-connector explained
 
-The rabbitmq-http-connector reads message from RabbitMQ (Source) and calls a HTTP endpoint where it send the message content as a HTTP request body. The code is rather simple as we will see in following sections. There are things which are applicable to every connector and there are things which are specific to that connector only, they will be called out as we explain.
+The rabbitmq-http-connector reads message from RabbitMQ (Source) and calls an HTTP endpoint where it sends the message content as an HTTP request body. The code is rather simple as we will see in following sections. There are things which are applicable to every connector and there are things which are specific to that connector only, they will be called out as we explain.
 
 #### The main()
 
@@ -45,7 +45,7 @@ connectordata, err := common.ParseConnectorMetadata()
 
 ```
 
-The fields in connector metadata are basic metadata which is not specific to a event source:
+The fields in connector metadata are basic metadata which is not specific to an event source:
 
 ```
 // ConnectorMetadata contains common fields used by connectors
@@ -60,7 +60,7 @@ type ConnectorMetadata struct {
 }
 ```
 
-The second set of env variables we are getting is specific to RabbitMQ and how to connect to it and we populate the rabbitMQConnector struct with earlier created metadata and host on which to connect to for RabbitMQ and other things such as consumer channel and producer channel. For finding out which attributes are applicable for an event source, it is best to refer to Keda documentation for that event source. For example for [RabbitMQ the Keda documentation is here](https://keda.sh/docs/2.0/scalers/rabbitmq-queue/)
+The second set of env variables we are getting is specific to RabbitMQ and how to connect to it, and we populate the rabbitMQConnector struct with earlier created metadata and host on which to connect to for RabbitMQ and other things such as consumer channel and producer channel. For finding out which attributes are applicable for an event source, it is best to refer to Keda documentation for that event source. For example for [RabbitMQ the Keda documentation is here](https://keda.sh/docs/2.0/scalers/rabbitmq-queue/)
 
 ```
 type rabbitMQConnector struct {
@@ -72,7 +72,7 @@ type rabbitMQConnector struct {
 }
 ```
 
-At end of main we are calling consume messages method, let's dive into that.
+At the end of main we are calling consume messages method, let's dive into that.
 
 ```
 conn.consumeMessage()
@@ -98,13 +98,13 @@ headers := http.Header{
 
 * Form rest of HTTP request amd call HTTPHandler method from common package. This method is common for all connectors with destination as HTTPEndPoint.
 
-* If the HTTP call errors with a HTTP code other than 200 then , call errorHandler. This logic is specific to the even source in this case the RabbitMQ.
+* If the HTTP call errors with an HTTP code other than 200 then , call errorHandler. This logic is specific to the even source in this case the RabbitMQ.
 
 * If the HTTP call succeeds with HTTP 200 then read the response body and use that to call responseHandler. This logic is specific to the even source in this case the RabbitMQ.
 
 #### HandleHTTPRequest
 
-The HandleHTTPRequest takes message and rest of information to make a HTTP call to HTTPEndpoint in ConnectorMetadata. This method is from common package, and we only use it.
+The HandleHTTPRequest takes a message and rest of information to make an HTTP call to HTTPEndpoint in ConnectorMetadata. This method is from common package, and we only use it.
 
 #### errorHandler
 

--- a/aws-sqs-http-connector/README.md
+++ b/aws-sqs-http-connector/README.md
@@ -18,9 +18,9 @@ The job of the connector is to read messages from the queue, call an HTTP endpoi
 - `AWS_REGION`: Region is mandatory for any aws connection.
   
 1) Through AWS endpoint  
-- `AWS_ENDPOINT` : SQS endpoint on which it is running, for local it can be http://localhost:4576.  
+- `AWS_ENDPOINT`: SQS endpoint on which it is running, for local it can be http://localhost:4576.  
 
-2) Through AWS aws key and secret
+2) Through AWS key and secret
 - `AWS_ACCESS_KEY`: aws access key of your account.
 - `AWS_SECRET_KEY`: aws secret key got from your account.  
 

--- a/aws-sqs-http-connector/main.go
+++ b/aws-sqs-http-connector/main.go
@@ -204,7 +204,7 @@ func main() {
 
 	sess, err := session.NewSession(config)
 	if err != nil {
-		logger.Error("not able create session using aws configuation", zap.Error(err))
+		logger.Error("not able create session using aws configuration", zap.Error(err))
 		return
 	}
 	svc := sqs.New(sess)

--- a/kafka-http-connector/README.md
+++ b/kafka-http-connector/README.md
@@ -2,7 +2,7 @@
 
 Kafka KEDA connector image can be used in the Kubernetes deployment as scaleTargetRef in scaledObject of [Apache Kafka scaler](https://keda.sh/docs/1.5/scalers/apache-kafka/).
 
-The job of the connector is to read messages from the topic, call an HTTP endpoint with the body of the message, and write response or error in the respective topics. Following enviornment variables are used by connector image as configuration to connect and authenticate with Apache Kafka cluster which should be defined in the Kubernetes deployment manifest.
+The job of the connector is to read messages from the topic, call an HTTP endpoint with the body of the message, and write response or error in the respective topics. Following environment variables are used by connector image as configuration to connect and authenticate with Apache Kafka cluster which should be defined in the Kubernetes deployment manifest.
 
 - `TOPIC`: topic from which messages are read.
 - `HTTP_ENDPOINT`: http endpoint to post request.


### PR DESCRIPTION
Fixed a small series of typos and missing commas.

Didn't include the main REAME.md as there is already a PR open for it https://github.com/fission/keda-connectors/pull/31