### PR TITLE
kafka-http-connector: TLS CA, CERT, and KEY should all be optional

### DIFF
--- a/kafka-http-connector/main.go
+++ b/kafka-http-connector/main.go
@@ -103,6 +103,7 @@ func parseKafkaMetadata(logger *zap.Logger) (kafkaMetadata, error) {
 	}
 
 	if meta.tls == "enable" {
+		// if either CERT or KEY are provided, both must be provided
 		if os.Getenv("CERT") != "" && os.Getenv("KEY") == "" {
 			return meta, errors.New("cert given but no key, both required")
 		}
@@ -111,7 +112,9 @@ func parseKafkaMetadata(logger *zap.Logger) (kafkaMetadata, error) {
 			return meta, errors.New("key given but no cert, both required")
 		}
 
+		// CA is optional
 		meta.ca = os.Getenv("CA")
+		// CERT and KEY must be provided as a pair, but both are optional
 		meta.cert = os.Getenv("CERT")
 		meta.key = os.Getenv("KEY")
 	}

--- a/kafka-http-connector/main.go
+++ b/kafka-http-connector/main.go
@@ -103,19 +103,16 @@ func parseKafkaMetadata(logger *zap.Logger) (kafkaMetadata, error) {
 	}
 
 	if meta.tls == "enable" {
-		if os.Getenv("CA") == "" {
-			return meta, errors.New("no ca given")
+		if os.Getenv("CERT") != "" && os.Getenv("KEY") == "" {
+			return meta, errors.New("cert given but no key, both required")
 		}
+
+		if os.Getenv("KEY") != "" && os.Getenv("CERT") == "" {
+			return meta, errors.New("key given but no cert, both required")
+		}
+
 		meta.ca = os.Getenv("CA")
-
-		if os.Getenv("CERT") == "" {
-			return meta, errors.New("no cert given")
-		}
 		meta.cert = os.Getenv("CERT")
-
-		if os.Getenv("KEY") == "" {
-			return meta, errors.New("no key given")
-		}
 		meta.key = os.Getenv("KEY")
 	}
 


### PR DESCRIPTION
This PR addresses Issue #55 where enabling TLS makes CA, CERT, and KEY required. This brings parity with `KEDA 2.1` as seen [here](https://github.com/kedacore/keda/blob/896ff4d58a84a1f2a3452763bd47ca74bd1fdb8a/pkg/scalers/kafka_scaler.go#L166).