### PR TITLE
use correct topic for responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Kind Cluster
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: v0.11.1
+          version: v0.18.0
       - name: Install KEDA using HELM
         run: |
           cd test/
@@ -123,7 +123,7 @@ jobs:
       - name: Install Kind Cluster
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: v0.11.1
+          version: v0.18.0
       - name: Install KEDA using HELM
         run: |
           cd test/
@@ -192,7 +192,7 @@ jobs:
       - name: Install Kind Cluster
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: v0.11.1
+          version: v0.18.0
       - name: Install KEDA using HELM
         run: |
           cd test/
@@ -247,7 +247,7 @@ jobs:
       - name: Install Kind Cluster
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: v0.11.1
+          version: v0.18.0
       - name: Install KEDA using HELM
         run: |
           cd test/
@@ -321,7 +321,7 @@ jobs:
       - name: Install Kind Cluster
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: v0.11.1
+          version: v0.18.0
       - name: Install KEDA using HELM
         run: |
           cd test/
@@ -394,7 +394,7 @@ jobs:
       - name: Install Kind Cluster
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: v0.11.1
+          version: v0.18.0
       - name: Install KEDA using HELM
         run: |
           cd test/

--- a/kafka-http-connector/main.go
+++ b/kafka-http-connector/main.go
@@ -265,7 +265,7 @@ func (conn *kafkaConnector) errorHandler(err error) {
 				zap.Error(e),
 				zap.String("source", conn.connectorData.SourceName),
 				zap.String("message", err.Error()),
-				zap.String("topic", conn.connectorData.Topic))
+				zap.String("topic", conn.connectorData.ErrorTopic))
 		}
 	} else {
 		conn.logger.Error("message received to publish to error topic, but no error topic was set",
@@ -286,7 +286,7 @@ func (conn *kafkaConnector) responseHandler(msg string, headers []sarama.RecordH
 		if err != nil {
 			conn.logger.Warn("failed to publish response body from http request to topic",
 				zap.Error(err),
-				zap.String("topic", conn.connectorData.Topic),
+				zap.String("topic", conn.connectorData.ResponseTopic),
 				zap.String("source", conn.connectorData.SourceName),
 				zap.String("http endpoint", conn.connectorData.HTTPEndpoint))
 			return false


### PR DESCRIPTION
### Description
Use correct response topics for responses.
For 
- response use `conn.connectorData.ResponseTopic` 
- for error response use `conn.connectorData.ErrorTopic`

### Motivation
Fixes: #110
